### PR TITLE
Updated bonecp dependency to 0.8.0-RELEASE

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [com.jolbox/bonecp "0.7.1.RELEASE"]
+                 [com.jolbox/bonecp "0.8.0.RELEASE"]
                  [org.slf4j/slf4j-api "1.7.2"]]
   :profiles {:dev {:dependencies [[org.slf4j/slf4j-nop "1.7.2"]
                                   [postgresql "9.1-901-1.jdbc4"]


### PR DESCRIPTION
The old version was causing a (very hard to track down) conflict with lein-cljsbuild, due to BoneCP requiring an older version of the the Guava libraries.
